### PR TITLE
Support munit 2.0 with gcc version 4.8.5, change to gzip for archive, fixup README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ scan-build:       ## Use scan-build for static analysis
 .PHONY: archive
 archive:          ## Create uefistored-X.Y.Z.tar.gz for release of most recent tag
 	git archive --format=tar --prefix=uefistored-$(RELEASE)/ $(TAG) \
-		| xz > $(ARCHIVE)
+		| gzip > $(ARCHIVE)
 
 -include $(DEPS)
 include Docker.mk

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ openssl req -newkey rsa:4096 -nodes -new -x509 -sha256 -days 3650 \
 # Self-sign KEK and creat KEK.auth
 # NOTE: because this cert is self-signed it will not be provisionable from
 # the guest, only as a file for uefistored to read from /usr/share/uefistored
-./create-auth -k KEK.key -c KEK.crt KEK KEK.auth KEK.crt
+/opt/xensource/libexec/create-auth -k KEK.key -c KEK.crt KEK KEK.auth KEK.crt
 
 # Download Microsoft UEFI CA 2011
 curl 'https://www.microsoft.com/pkiops/certs/MicCorUEFCA2011_2011-06-27.crt' --output MicCorUEFCA2011_2011-06-27.crt
@@ -66,7 +66,7 @@ curl 'https://www.microsoft.com/pkiops/certs/MicWinProPCA2011_2011-10-19.crt' --
 # * [MicCorUEFCA2011_2011-06-27.crt](https://go.microsoft.com/fwlink/p/?linkid=321194)
 
 # Sign Microsoft certs with your KEK and create a db.auth
-./create-auth -k KEK.key -c KEK.crt db db.auth MicWinProPCA2011_2011-10-19.crt MicCorUEFCA2011_2011-06-27.crt
+/opt/xensource/libexec/create-auth -k KEK.key -c KEK.crt db db.auth MicWinProPCA2011_2011-10-19.crt MicCorUEFCA2011_2011-06-27.crt
 
 cp *.auth /usr/share/uefistored/
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -75,6 +75,9 @@ test: test.c $(OBJS) $(TEST_OBJS) $(HDRS) $(MUNIT_OBJS)
 %.o: %.c
 	$(CC) -o $@ -c $< $(CFLAGS) $(INC) $(SANITIZERS)
 
+munit/munit.o: munit/munit.c
+	$(CC) -o $@ -c $< $(CFLAGS) --std=c99 $(INC) $(SANITIZERS)
+
 .PHONY: clean
 clean:
 	rm -f $(OBJS) $(TEST_OBJS) $(MUNIT_OBJS) test test-nosan


### PR DESCRIPTION
Trying to compile munit 2.0 with gcc version 4.8.5 (as found our build environment for Koji) results in a complaint about c99, yet 2.0 is the only available public archive of the project.  This adds the -std=c99 tag for building munit and so enables our munit tests to be built and then ran in the Koji environment.

It also changes the archive make target to use gzip instead of xz (although this is not used in our RPM).

It also adds a small README fix.