### PR TITLE
Print cert failure and add configurable debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2021-07-16
+### Added
+- Print out PKCS7 certs when auth variable verification fails.
+
 ## [1.1.0] - 2021-07-16
 ### Added
 - Support for configuring the log level via /etc/uefistored/uefistored.conf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2021-07-16
+### Added
+- Support for configuring the log level via /etc/uefistored/uefistored.conf.
+
 ## [1.0.1] - 2021-07-15
 ### Fixed
 - Support Windows update KB4535680

--- a/Common.mk
+++ b/Common.mk
@@ -1,3 +1,8 @@
+PKGS := libxml-2.0  \
+        libssl      \
+        libcrypto   \
+        libseccomp
+
 SRCS :=                                                         \
         src/common.c                                            \
         src/depriv.c                                            \
@@ -14,14 +19,3 @@ SRCS :=                                                         \
         src/variable.c                                          \
         src/xapi.c                                              \
         src/xen_variable_server.c
-
-LDFLAGS := $$(pkg-config --libs libxml-2.0)		\
-			-lxenstore							\
-			-lxenctrl							\
-			-lxenforeignmemory					\
-			-lxendevicemodel					\
-			-lxenevtchn							\
-			-lxentoolcore						\
-			-lseccomp							\
-			-lssl				    			\
-			-lcrypto							\

--- a/Common.mk
+++ b/Common.mk
@@ -1,4 +1,5 @@
-PKGS := libxml-2.0  \
+PKGS := glib-2.0    \
+        libxml-2.0  \
         libssl      \
         libcrypto   \
         libseccomp

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,21 @@ include Common.mk
 TARGET := uefistored
 CC ?= gcc
 
+PKGS += xencontrol          \
+        xenstore            \
+        xenforeignmemory    \
+        xendevicemodel      \
+        xenevtchn           \
+        xentoolcore
+
 OBJS := $(patsubst %.c,%.o,$(SRCS))
 
-CFLAGS = -I$(shell pwd)/inc $$(pkg-config --cflags libxml-2.0)
+CFLAGS := -I$(shell pwd)/inc
+CFLAGS += $(foreach pkg,$(PKGS),$$(pkg-config --cflags $(pkg)))
 CFLAGS += -fshort-wchar -fstack-protector -O2
 CFLAGS += -Wp,-MD,$(@D)/.$(@F).d -MT $(@D)/$(@F)
+
+INC := $(foreach pkg,$(PKGS),$$(pkg-config --libs $(pkg)))
 
 DEPS     = ./.*.d src/.*.d src/uefi/.*.d
 
@@ -20,12 +30,12 @@ all: $(TARGET) $(TARGET)-debug
 
 uefistored:       ## Build uefistored
 $(TARGET): src/$(TARGET).c $(OBJS)
-	$(CC) -o $@ $< $(LDFLAGS) $(CFLAGS) $(OBJS) $(INC)
+	$(CC) -o $@ $< $(CFLAGS) $(OBJS) $(INC)
 
 uefistored-debug: ## Build uefistored with debug symbols
 $(TARGET)-debug: CFLAGS += -g -grecord-gcc-switches
 $(TARGET)-debug: src/$(TARGET).c $(OBJS)
-	$(CC) -o $@ $< $(LDFLAGS) $(CFLAGS) $(OBJS) $(INC)
+	$(CC) -o $@ $< $(CFLAGS) $(OBJS) $(INC)
 
 %.o: %.c
 	$(CC) -o $@ -c $< $(CFLAGS) $(INC)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,29 @@ cp *.auth /var/lib/uefistored/
 Production PCA 2011 from
 [here](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-secure-boot-key-creation-and-management-guidance)
 
+## Logging
+
+`uefistored` supports defining log levels using the file /etc/uefistored/uefistored.conf.
+
+In /etc/uefistored/uefistored.conf, set the "loglevel" variable, such as:
+
+```
+# /etc/uefistored/uefistored.conf
+[default]
+loglevel=DEBUG
+```
+
+Possible values for `loglevel` are:
+
+| loglevel  |
+|-----------|
+|  `DEBUG`  |
+| `WARNING` |
+|  `ERROR`  |
+|  `INFO`   |
+
+The default level is INFO.
+
 ## Deployment during Test
 
 If you just want to deploy to a known host:

--- a/inc/log.h
+++ b/inc/log.h
@@ -13,7 +13,7 @@ enum loglevel {
     LOGLEVEL_DEBUG,
 };
 
-extern const enum loglevel loglevel;
+extern enum loglevel loglevel;
 
 #define ERROR(...)                                                             \
     do {                                                                       \
@@ -60,5 +60,6 @@ void dprint_data(const void *data, size_t datasz);
 void dprint_variable(const variable_t *var);
 void dprint_variable_list(const variable_t *vars, size_t n);
 void dprint_name(const UTF16 *name, size_t namesz);
+void logging_init(void);
 
 #endif // __H_LOG__

--- a/inc/uefi/pkcs7_verify.h
+++ b/inc/uefi/pkcs7_verify.h
@@ -21,5 +21,6 @@ uint8_t *wrap_with_content_info(const uint8_t *data, uint32_t size,  uint32_t *n
 bool is_content_info(const uint8_t *data, size_t data_size);
 bool pkcs7_verify(PKCS7 *pkcs7, X509 *TrustedCert,
                   const uint8_t *new_data, uint64_t new_data_size);
+int pkcs7_print(PKCS7 *pkcs7);
 
 #endif // __H_PKCS7_VERIFY_

--- a/src/uefi/auth.c
+++ b/src/uefi/auth.c
@@ -1356,6 +1356,14 @@ verify_time_based_payload(UTF16 *name, size_t namesz, EFI_GUID *guid,
     free(new_data);
 
     if (!verify_status) {
+        DEBUG("Auth var failed. PKCS7 was:\n");
+        PKCS7 *pkcs7 = pkcs7_from_auth(efi_auth);
+        if (pkcs7) {
+            pkcs7_print(pkcs7);
+            PKCS7_free(pkcs7);
+        } else {
+            INFO("..failed to parse PKCS7 from auth\n");
+        }
         free(wrap_data);
         return EFI_SECURITY_VIOLATION;
     }

--- a/src/uefi/authlib.c
+++ b/src/uefi/authlib.c
@@ -233,6 +233,10 @@ auth_lib_process_variable(UTF16 *variable_name, size_t namesz,
 {
     EFI_STATUS status;
 
+    DPRINTF("processing auth variable: ");
+    dprint_name(variable_name, namesz);
+    DPRINTF("\n");
+
     if (compare_guid(vendor_guid, &gEfiGlobalVariableGuid) &&
         (strcmp16(variable_name, EFI_PLATFORM_KEY_NAME) == 0)) {
         status = process_var_with_pk(variable_name, namesz, vendor_guid, data,

--- a/src/uefistored.c
+++ b/src/uefistored.c
@@ -40,8 +40,6 @@
 
 #define IOREQ_BUFFER_SLOT_NUM 511 /* 8 bytes each, plus 2 4-byte indexes */
 
-const enum loglevel loglevel = LOGLEVEL_INFO;
-
 struct backend *backend = NULL;
 struct backend xapidb;
 static bool resume;
@@ -624,6 +622,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
+    logging_init();
     install_sighandlers();
 
     while (1) {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,8 @@ HDRS := $(shell find . -type f -name '*.h')
 CFLAGS += -g -Wall -Werror -fshort-wchar
 CFLAGS += $(foreach pkg,$(PKGS),$$(pkg-config --cflags $(pkg)))
 
+CFLAGS += -DCONFIG_PATH=\"./conf/test.conf\"
+
 INC := -I../inc/ -Idata/ -I. -I../libs -Iinc -Imock/ -Isrc/ -I/usr/include/libxml2 
 INC += -I./munit/
 INC += $(foreach pkg,$(PKGS),$$(pkg-config --libs $(pkg)))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,21 +1,16 @@
 include ../Common.mk
 
-# Override to omit unused libs (i.e., xen libs)
-LDFLAGS := $$(pkg-config --libs libxml-2.0)     \
-            -lseccomp                           \
-            -lssl                               \
-            -lcrypto
-
 CC := gcc
 
 SRCS := $(patsubst %,../%,$(SRCS))
 HDRS := $(shell find . -type f -name '*.h')
 
-LIBS := -lssl -lcrypto -lxml2
 CFLAGS += -g -Wall -Werror -fshort-wchar
+CFLAGS += $(foreach pkg,$(PKGS),$$(pkg-config --cflags $(pkg)))
 
 INC := -I../inc/ -Idata/ -I. -I../libs -Iinc -Imock/ -Isrc/ -I/usr/include/libxml2 
 INC += -I./munit/
+INC += $(foreach pkg,$(PKGS),$$(pkg-config --libs $(pkg)))
 
 # Add mocks
 TEST_SRCS += mock/XenVariable.c \
@@ -69,7 +64,7 @@ valgrind: clean test
 			./test
 
 test: test.c $(OBJS) $(TEST_OBJS) $(HDRS) $(MUNIT_OBJS)
-	$(CC) -o $@ $< $(INC) $(LIBS) $(OBJS) \
+	$(CC) -o $@ $< $(INC) $(OBJS) \
 		$(TEST_OBJS) $(MUNIT_OBJS) $(CFLAGS) $(SANITIZERS) \
 		$(LDFLAGS)
 

--- a/tests/conf/test.conf
+++ b/tests/conf/test.conf
@@ -1,0 +1,2 @@
+[default]
+loglevel=ERROR

--- a/tests/test.c
+++ b/tests/test.c
@@ -12,8 +12,6 @@
 #include "test_suites.h"
 
 struct backend *backend = NULL;
-const enum loglevel loglevel = LOGLEVEL_ERROR;
-
 
 MunitSuite other_suites[] = {
     {
@@ -88,6 +86,8 @@ int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)])
     int ret;
     char **newargs;
     char *no_fork = "--no-fork";
+
+    logging_init();
 
     /* Force --no-fork */
     newargs = malloc((argc + 1) * sizeof(char*));


### PR DESCRIPTION
This PR adds the ability to print out the failed certificates if an authenticated variable cert failure occurs.  Because certificates contain a good amount of information, and in order to avoid polluting the logs, this is only done if the log level is set to DEBUG.  Because the log level was previously compiled in, this is not easy to change conveniently on a running system.  Therefore, this PR also adds support for a small configuration file located at `/etc/uefistored/uefistored.conf` that contains just one option: `loglevel`.

The config file looks like this:
```
# /etc/uefistored/uefistored.conf
loglevel=DEBUG
```

Other values for loglevel may be `ERROR`, `INFO`, or `WARNING`.  If the file or its directory are missing, then the log level will default to `INFO` (the level used in previous uefistored versions).  If the variable is missing from the file or the value of `loglevel` is unrecognizable, `uefistored` defaults the log level to `INFO`.

It is read only once: when `uefistored` starts.  There would be no other option because it can not reach outside of its `chroot` later at runtime.