### PR TITLE
build: fix new GCC 11 warnings

### DIFF
--- a/inc/variable.h
+++ b/inc/variable.h
@@ -69,7 +69,7 @@ static inline bool variable_is_valid(const variable_t *var) {
 }
 
 variable_t *find_variable(const UTF16 *name, size_t namesz, const EFI_GUID *guid,
-                          variable_t variables[MAX_VAR_COUNT], size_t n);
+                          variable_t *variables, size_t n);
 
 /* Get the namesz with no end of string char '\0' */
 #define variable_serialized_namesz(var) ((var)->namesz)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,11 +8,21 @@ LDFLAGS := $$(pkg-config --libs libxml-2.0)     \
 
 CC := gcc
 
+GCCVERSION := $(shell gcc --version | grep ^gcc | sed 's/^.* //g')
+GCCMAJOR := $(shell echo $(GCCVERSION) | cut -f1 -d.)
+GCC_GTE_11 := $(shell [[ "$(GCCMAJOR)" -gt 10 ]] && echo "true")
+
 SRCS := $(patsubst %,../%,$(SRCS))
 HDRS := $(shell find . -type f -name '*.h')
 
 LIBS := -lssl -lcrypto -lxml2
 CFLAGS += -g -Wall -Werror -fshort-wchar
+
+# If GCC version is equal to or greater than 11.0.0 then suppress vla-parameter errors because munit
+# will otherwise fail.
+ifeq ($(GCC_GTE_11),true)
+CFLAGS += -Wno-error=vla-parameter
+endif
 
 INC := -I../inc/ -Idata/ -I. -I../libs -Iinc -Imock/ -Isrc/ -I/usr/include/libxml2 
 INC += -I./munit/


### PR DESCRIPTION
Compiling the tests with GCC11 with flag -Werror fails due to two
violations.  One is -Warray-parameter and the other is -Wvla-parameter.

This commit fixes the code violating the array-parameter check.  It
suppresses the vla-parameter check when building tests because the
violating code exists in the munit dependency, not in uefistored itself.

Some future vla-parameter violations may wrongfully suppressed as a side
effect when building the tests.  The production build will not have that
error suppressed.

Signed-off-by: Bobby Eshleman <bobby.eshleman@gmail.com>