### PR TITLE
fix(pkcs7): print OpenSSL errors when PKCS7 verify fails

### DIFF
--- a/src/uefi/pkcs7_verify.c
+++ b/src/uefi/pkcs7_verify.c
@@ -391,8 +391,8 @@ bool pkcs7_verify(PKCS7 *pkcs7, X509 *trusted_cert, const uint8_t *new_data,
 
     if (!status) {
         ERROR("PKCS7_verify() failed\n");
-        ERR_print_errors_fp(stderr);
         ERR_load_crypto_strings();
+        ERR_print_errors_fp(stderr);
         ERR_free_strings();
     }
 


### PR DESCRIPTION
In order for OpenSSL errors to be printed reliably, the crypto
strings must be loaded prior to the print.

This commit moves the string loading prior to printing the errors.

Signed-off-by: Bobby Eshleman <bobby.eshleman@gmail.com>