### PR TITLE
fix: /usr/share/uefistored/PK.auth -> /var/lib/uefistored/PK.auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+- PK.auth is now opened from /var/lib/uefistored/PK.auth
+
 ## [1.2.0] - 2021-07-16
 ### Added
 - Print out PKCS7 certs when auth variable verification fails.

--- a/src/uefistored.c
+++ b/src/uefistored.c
@@ -125,10 +125,9 @@ struct auth_data auth_files[] = {
     DEFINE_AUTH_FILE("/var/lib/uefistored/KEK.auth", L"KEK",
                         EFI_GLOBAL_VARIABLE_GUID, AT_ATTRS),
     /*
-     * PK should be distributed with uefistored, so should
-     * be stored in /usr/share/ (refer to Linux FHS)
+     * PK should be distributed with uefistored.
      */
-    DEFINE_AUTH_FILE("/usr/share/uefistored/PK.auth", L"PK",
+    DEFINE_AUTH_FILE("/var/lib/uefistored/PK.auth", L"PK",
                         EFI_GLOBAL_VARIABLE_GUID, AT_ATTRS),
 };
 


### PR DESCRIPTION
To give users the option of changing the PK.auth but still protect the
default PK, let uefistored open the PK from /var/lib/uefistored.

According to the FHS, files in /usr/share/ should not be modified by
users.

Signed-off-by: Bobby Eshleman <bobby.eshleman@gmail.com>