### PR TITLE
Fix build on uefistored 1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ PKGS += xencontrol          \
 
 OBJS := $(patsubst %.c,%.o,$(SRCS))
 
-CFLAGS := -I$(shell pwd)/inc
-CFLAGS += $(foreach pkg,$(PKGS),$$(pkg-config --cflags $(pkg)))
+PKG_CFLAGS := $(foreach pkg,$(PKGS),$$(pkg-config --cflags $(pkg)))
+
+CFLAGS = -I$(shell pwd)/inc
+CFLAGS += $(PKG_CFLAGS)
 CFLAGS += -fshort-wchar -fstack-protector -O2
 CFLAGS += -Wp,-MD,$(@D)/.$(@F).d -MT $(@D)/$(@F)
 


### PR DESCRIPTION
Due to changes in commit d4f9d17bdd9c0284817ca3b43775a5c2f126d904,
the $(@D) and $(@F) special variables are only evaluated once, rather
than for each target.

This commit changes the assignment operator for CFLAGS back to = instead
of :=.