### PR TITLE
WIP: fix: allow no db and no dbx, but still prevent bad configs

### DIFF
--- a/src/uefistored.c
+++ b/src/uefistored.c
@@ -122,6 +122,15 @@ struct auth_data auth_files[] = {
                         EFI_IMAGE_SECURITY_DATABASE_GUID, AT_ATTRS),
     DEFINE_AUTH_FILE("/var/lib/uefistored/dbx.auth", L"dbx",
                         EFI_IMAGE_SECURITY_DATABASE_GUID, AT_ATTRS),
+
+    /*
+     * Ordering matters. The KEK element must always come before the PK
+     * element.  We need to refuse to load the PK if the KEK fails, or else PK
+     * will be set which enables SB and signature checking, causing users to be
+     * unable to update the dbx/db variables (because they'll all fail to pass
+     * verification without a KEK to verify them!). See auth_lib_load() for
+     * the implementation.
+     */
     DEFINE_AUTH_FILE("/var/lib/uefistored/KEK.auth", L"KEK",
                         EFI_GLOBAL_VARIABLE_GUID, AT_ATTRS),
     /*


### PR DESCRIPTION
Allowing a PK to be installed with no KEK creates systems in which users
can not install a db/dbx. This matters for Windows especially, because
it tries to install a dbx when updating. This was fixed but loading the
certs in order: db -> dbx -> KEK -> PK, and if any preceding certs
failed to load in the chain, then no following certs would be loaded.
Unfortunately, this also placed an implicit requirement that systems
have both a db and dbx, which should not be required... A user may
simply want the MSFT KEK and a default PK on the system, and wants to
allow Windows to install the dbx later at run time.

Signed-off-by: Bobby Eshleman <bobby.eshleman@gmail.com>