### PR TITLE
logging: demote or remove superfluous error messages

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -135,8 +135,7 @@ out:
         loglevel = LOGLEVEL_INFO;
         ERROR("%s\n", err->message);
         g_error_free(err);
-        INFO("Opening/parsing %s failed, defaulting to loglevel=INFO\n",
-             CONFIG_PATH);
+        INFO("%s not found, defaulting to loglevel=INFO\n", CONFIG_PATH);
     }
     if (val) {
         free(val);

--- a/src/uefi/authlib.c
+++ b/src/uefi/authlib.c
@@ -61,7 +61,10 @@ static int load_auth(struct auth_data *auth)
     ret = stat(auth->path, &statbuf);
 
     if (ret < 0) {
-        ERROR("failed to stat %s\n", auth->path);
+        /*
+         * Auth files may not be on disk if the user hasn't configured
+         * secure boot for the host. Quietly ignore this situation.
+         */
         return ret;
     }
 

--- a/src/uefistored.c
+++ b/src/uefistored.c
@@ -329,14 +329,13 @@ void handle_ioreq(struct ioreq *ioreq)
     uint32_t size = ioreq->size;
 
     if (!io_port_enabled) {
-        ERROR("ioport not yet enabled!\n");
+        WARNING("ioport not yet enabled!\n");
         return;
     }
 
+    /* If this IO was not intended for uefistored, ignore quietly */
     if (!(io_port_addr <= port_addr &&
           port_addr < io_port_addr + io_port_size)) {
-        ERROR("port addr 0x%lx not in range (0x%02lx-0x%02lx)\n", port_addr,
-              io_port_addr, io_port_addr + io_port_size - 1);
         return;
     }
 
@@ -955,7 +954,7 @@ int main(int argc, char **argv)
     status = auth_lib_initialize(auth_files, ARRAY_SIZE(auth_files));
 
     if (status != EFI_SUCCESS) {
-        ERROR("auth_lib_initialization() failed, status=%s (0x%lx)",
+        ERROR("auth_lib_initialization() failed, status=%s (0x%lx)\n",
               efi_status_str(status), status);
 
         goto err;


### PR DESCRIPTION
This commit either reduces overzealous ERROR() messages to WARNING()
messages. If the message occurs during normal operation of a VM (such as
uefistored receiving an IO event that it doesn't know how to handle),
then the message is removed altogether.

Finally, a newline char was added to a message that was missing one.

Signed-off-by: Bobby Eshleman <bobby.eshleman@gmail.com>