### PR TITLE
Don't wait for ioreq server frames to appear

### DIFF
--- a/src/uefistored.c
+++ b/src/uefistored.c
@@ -571,7 +571,6 @@ int main(int argc, char **argv)
 {
     xc_dominfo_t domain_info;
     shared_iopage_t *shared_iopage;
-    uint64_t ioreq_server_pages_cnt;
     size_t vcpu_count = 1;
     int ret;
     int option_index = 0;
@@ -724,24 +723,6 @@ int main(int argc, char **argv)
               domid);
         goto err;
     }
-
-    /* Retrieve IO req server page count, retry until available */
-    for (i = 0; i < 10; i++) {
-        ret = xc_hvm_param_get(xc_handle, domid,
-                               HVM_PARAM_NR_IOREQ_SERVER_PAGES,
-                               &ioreq_server_pages_cnt);
-        if (ret < 0) {
-            ERROR("xc_hvm_param_get failed: %d, %s\n", errno, strerror(errno));
-            goto err;
-        }
-
-        if (ioreq_server_pages_cnt != 0)
-            break;
-
-        printf("Waiting for ioreq server");
-        usleep(100000);
-    }
-    INFO("HVM_PARAM_NR_IOREQ_SERVER_PAGES = %ld\n", ioreq_server_pages_cnt);
 
     xc_interface_close(xc_handle);
     xc_handle = NULL;


### PR DESCRIPTION
Port of https://github.com/xapi-project/varstored/commit/f8c2656be1cfca35bb9297b97d9af962f51f19f9 :

> This logically reverts c/s https://github.com/xapi-project/varstored/commit/1a4bc4fbdd5bed4ad26aec24aa1a75374f34e152 "CA-294027: Wait for ioreq server pages
> to become available".

> The workaround was made obsolete by c/s https://github.com/xapi-project/varstored/commit/f00b12dc1d0c6e1e0574a3dc8db59a66eb533fa2 "CA-322067: Use new
> resource mapping API".

> Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>