### PR TITLE
[WIP] Switch to using new xendevicemodel_nr_vcpus() API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ include Common.mk
 TARGET := uefistored
 CC ?= gcc
 
-PKGS += xencontrol          \
-        xenstore            \
+PKGS += xenstore            \
         xenforeignmemory    \
         xendevicemodel      \
         xenevtchn           \


### PR DESCRIPTION
Port of https://github.com/xapi-project/varstored/commit/fde707c59f7a189e1d4e97c1a4ee1a2d0c378ad1 :

> This is a stable API replacing the need to use the unstable
> xc_domain_getinfo().  This in turn drops the dependency on libxenctrl.

> As part of dropping the xenctrl.h include, include xen/memory.h for the
> resource mapping constants, and swap xc_evtchn_port_or_error_t for
> xenevtchn_port_or_error_t which is provided by xenevtchn.h.

> Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>