### PR TITLE
Don't use -1 for unallocated evtchn ports

### DIFF
--- a/src/uefistored.c
+++ b/src/uefistored.c
@@ -794,7 +794,7 @@ int main(int argc, char **argv)
 
     /* Initialize Port IO for domU */
     INFO("%lu vCPU(s)\n", vcpu_count);
-    ioreq_local_ports = malloc(sizeof(xc_evtchn_port_or_error_t) * vcpu_count);
+    ioreq_local_ports = calloc(sizeof(xc_evtchn_port_or_error_t), vcpu_count);
 
     if (!ioreq_local_ports) {
         ERROR("Failed to alloc ioreq_local_ports\n");


### PR DESCRIPTION
Port of https://github.com/xapi-project/varstored/commit/7c7025e1adab52db51320f2ffc224b9f638c626c :

> evtchn port 0 is never valid.  Use calloc() instead of malloc().

> Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>

For uefistored code, the only change is to use `calloc` instead of `malloc`

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>