### PR TITLE
Report correct boot mode for started VM

### DIFF
--- a/src/uefistored.c
+++ b/src/uefistored.c
@@ -878,13 +878,17 @@ int main(int argc, char **argv)
      * have already propogated and terminated the process, and so they are not
      * part of the error message.
      */
-    if (secure_boot_enabled && (!secure_boot_on() || !sb_certs_exist())) {
-        backend_notify();
-        ERROR(
-            "Secure boot was enabled, but certificates are missing or weren't loaded. "
-            "Please enroll a PK, KEK, and db before enabling secure boot. "
-            "Killing uefistored to stop the VM...\n");
-        exit(1);
+    if (secure_boot_enabled) {
+        if (!secure_boot_on() || !sb_certs_exist()) {
+            backend_notify();
+            ERROR(
+                "Secure boot was enabled, but certificates are missing or weren't loaded. "
+                "Please enroll a PK, KEK, and db before enabling secure boot. "
+                "Killing uefistored to stop the VM...\n");
+            exit(1);
+        } else {
+            INFO("VM start in secure boot mode\n");
+        }
     } else {
         INFO("Secure boot disabled by host admin, not requiring certs to boot.\n");
     }


### PR DESCRIPTION
For now, when a VM is started with SB enabled, the log says without SB.

Original commit from Andrei Semenov <andrei.semenov@vates.fr>:
- https://github.com/xcp-ng/uefistored/pull/41/commits/c16e290c1ca56ddd86d75b7912d7c8dd5e404aee

Co-authored-by: Andrei Semenov <andrei.semenov@vates.fr>
Signed-off-by: BenjiReis <benjamin.reis@vates.fr>